### PR TITLE
chore: 添加 sdk-local nil context 修复

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "templates"]
 	path = templates
 	url = https://github.com/chainreactors/templates.git
+[submodule "sdk-local"]
+	path = sdk-local
+	url = https://github.com/wuchulonly/sdk.git
+	branch = codex/sdk-local-changes-20260614


### PR DESCRIPTION
## 变更
- 新增 `sdk-local` 子模块配置，指向 `wuchulonly/sdk` 的 `codex/sdk-local-changes-20260614` 分支。
- 记录 SDK commit `12bf618`，对应 SDK PR #23 的 nil context 源头修复。

## 范围控制
- 这个 PR 是从 `origin/feat/context-cap-search-proxy` 新切的干净分支。
- 只包含 `.gitmodules` 和 `sdk-local` gitlink 两个变更。
- 没有提交本地扫描结果、报告、`third_party/spray`、`utils-local` 或其他未跟踪产物。

## 关联
- SDK PR: https://github.com/chainreactors/sdk/pull/23

## 测试
- SDK 子仓库已执行：`go test ./...`
- 主仓库本 PR 只记录子模块指针，未改主仓库 Go 源码。