### PR TITLE
fix(evaluator): -e 目标评估循环基于累积进度总结防空转

### DIFF
--- a/pkg/agent/evaluator/evaluator.go
+++ b/pkg/agent/evaluator/evaluator.go
@@ -8,15 +8,17 @@ import (
 	"time"
 
 	"github.com/chainreactors/aiscan/pkg/agent/provider"
-	"github.com/chainreactors/aiscan/pkg/telemetry"
 	"github.com/chainreactors/aiscan/pkg/agent/truncate"
+	"github.com/chainreactors/aiscan/pkg/telemetry"
 )
 
 const (
-	defaultMaxRetries = 3
-	maxResultPreview  = 200
-	maxOutputPreview  = 3000
-	maxTraceSize      = 16000
+	defaultMaxRetries    = 3
+	maxResultPreview     = 200
+	maxOutputPreview     = 3000
+	maxToolArgsPreview   = 1200
+	maxToolResultPreview = 5000
+	maxTraceSize         = 64000
 )
 
 type Config struct {
@@ -46,9 +48,13 @@ func New(cfg Config) *Evaluator {
 	return &Evaluator{cfg: cfg}
 }
 
-func (e *Evaluator) Evaluate(ctx context.Context, goal, criteria string, messages []provider.ChatMessage, output string, turns int) (*Verdict, error) {
+// Evaluate judges goal completion against a CUMULATIVE progress summary rather
+// than a single round's raw trace. summary carries forward all prior rounds'
+// confirmed work so a round where the agent only replied without tool calls
+// cannot erase earlier progress from the evaluator's view.
+func (e *Evaluator) Evaluate(ctx context.Context, goal, criteria, summary string, messages []provider.ChatMessage, output string, turns int) (*Verdict, error) {
 	trace := buildTrace(messages, output, turns)
-	prompt := buildPrompt(goal, criteria, trace)
+	prompt := buildPrompt(goal, criteria, summary, trace)
 
 	var lastErr error
 	for attempt := 0; attempt < e.cfg.MaxRetries; attempt++ {
@@ -65,13 +71,14 @@ func (e *Evaluator) Evaluate(ctx context.Context, goal, criteria string, message
 	return nil, fmt.Errorf("goal eval failed after %d attempts: %w", e.cfg.MaxRetries, lastErr)
 }
 
-const systemPrompt = `You are a goal completion evaluator. Given the original goal, acceptance criteria, and execution trace, determine whether the goal was fully achieved.
+const systemPrompt = `You are a goal completion evaluator. You are given the original goal, acceptance criteria, a CUMULATIVE progress summary of everything accomplished across all rounds so far, and the latest round's execution trace.
 
 You MUST call the "verdict" tool with your evaluation. Do not respond with text.
 
 Rules:
+- Judge against the CUMULATIVE progress, not just the latest round. If the latest round shows no tool calls but the cumulative summary already shows substantial work, that earlier work still counts.
 - pass=true only if the goal was fully and correctly completed per the criteria
-- feedback: if pass=false, provide a specific, actionable instruction for what the agent should do next
+- feedback: if pass=false, provide a specific, actionable instruction for what the agent should do NEXT — name the concrete remaining work (e.g. untested subdomains, unverified vulnerability classes), and require the agent to perform actual tool calls, not just describe a plan.
 - Be strict: "ran without errors" is NOT the same as "fulfilled the goal"`
 
 var verdictTool = provider.ToolDefinition{
@@ -122,13 +129,16 @@ func (e *Evaluator) call(ctx context.Context, userPrompt string) (*Verdict, erro
 	return nil, fmt.Errorf("model did not call verdict tool")
 }
 
-func buildPrompt(goal, criteria, trace string) string {
+func buildPrompt(goal, criteria, summary, trace string) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "## Goal\n%s\n\n", goal)
 	if criteria != "" {
 		fmt.Fprintf(&sb, "## Acceptance Criteria\n%s\n\n", criteria)
 	}
-	fmt.Fprintf(&sb, "## Execution Trace\n%s", trace)
+	if strings.TrimSpace(summary) != "" {
+		fmt.Fprintf(&sb, "## Cumulative Progress (all rounds so far)\n%s\n\n", summary)
+	}
+	fmt.Fprintf(&sb, "## Latest Round Execution Trace\n%s", trace)
 	return sb.String()
 }
 
@@ -142,12 +152,22 @@ func buildTrace(messages []provider.ChatMessage, output string, turns int) strin
 	}
 	fmt.Fprintf(&sb, "Tool calls: %d\n", toolCallCount)
 
-	sb.WriteString("\nTool call sequence:\n")
+	sb.WriteString("\nTool calls and results:\n")
 	seq := 0
 	for _, msg := range messages {
 		for _, tc := range msg.ToolCalls {
 			seq++
-			fmt.Fprintf(&sb, "  [%d] %s\n", seq, tc.Function.Name)
+			fmt.Fprintf(&sb, "  [%d] %s id=%s\n", seq, tc.Function.Name, tc.ID)
+			if strings.TrimSpace(tc.Function.Arguments) != "" {
+				fmt.Fprintf(&sb, "      args: %s\n", truncate.Clip(tc.Function.Arguments, maxToolArgsPreview))
+			}
+		}
+		if msg.Role == "tool" {
+			body := toolMessageText(msg)
+			if strings.TrimSpace(body) == "" {
+				continue
+			}
+			fmt.Fprintf(&sb, "  result for %s:\n%s\n", msg.ToolCallID, indent(clipTraceText(body, maxToolResultPreview), "      "))
 		}
 	}
 
@@ -159,7 +179,127 @@ func buildTrace(messages []provider.ChatMessage, output string, turns int) strin
 	}
 
 	if output = strings.TrimSpace(output); output != "" {
-		fmt.Fprintf(&sb, "\nFinal output:\n%s\n", truncate.Clip(output, maxOutputPreview))
+		fmt.Fprintf(&sb, "\nFinal output:\n%s\n", clipTraceText(output, maxOutputPreview))
 	}
-	return truncate.Clip(sb.String(), maxTraceSize)
+	return clipTraceText(sb.String(), maxTraceSize)
+}
+
+func toolMessageText(msg provider.ChatMessage) string {
+	if msg.Content != nil {
+		return *msg.Content
+	}
+	if len(msg.ContentParts) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	for _, part := range msg.ContentParts {
+		switch part.Type {
+		case "text":
+			sb.WriteString(part.Text)
+		case "image_url":
+			if part.ImageURL != nil {
+				fmt.Fprintf(&sb, "[image: %s]\n", part.ImageURL.Detail)
+			} else {
+				sb.WriteString("[image]\n")
+			}
+		default:
+			fmt.Fprintf(&sb, "[%s]\n", part.Type)
+		}
+	}
+	return sb.String()
+}
+
+func indent(value, prefix string) string {
+	value = strings.TrimRight(value, "\n")
+	if value == "" {
+		return prefix
+	}
+	return prefix + strings.ReplaceAll(value, "\n", "\n"+prefix)
+}
+
+func clipTraceText(value string, maxBytes int) string {
+	tr := truncate.Head(value, truncate.Options{MaxLines: 400, MaxBytes: maxBytes})
+	if !tr.Truncated {
+		return tr.Content
+	}
+	if tr.FirstLineExceedsLimit {
+		return truncate.Clip(value, maxBytes)
+	}
+	return tr.Content + fmt.Sprintf(
+		"\n[truncated: showing %d/%d lines (%s of %s)]",
+		tr.OutputLines, tr.TotalLines, truncate.FormatSize(tr.OutputBytes), truncate.FormatSize(tr.TotalBytes))
+}
+
+const summarizeSystemPrompt = `You are a progress-tracking assistant for a security assessment agent. You maintain a single cumulative findings summary across many rounds of work.
+
+Do NOT continue the work or evaluate it. ONLY output the updated summary text, nothing else.`
+
+const summarizeInitialPrompt = `Below is the execution trace of the FIRST round of work toward the goal. Produce a structured progress summary that a later round and an evaluator will rely on.
+
+Use this EXACT format:
+
+## Goal
+[restate the goal in one or two lines]
+
+## Coverage
+- [each target / subdomain / component and whether it was tested, partially tested, or untouched]
+
+## Confirmed Findings
+- [each confirmed vulnerability: TYPE — exact URL/endpoint — the PoC request/command verbatim — the evidence observed. Preserve exact URLs, parameters, payloads, and response markers. Do NOT paraphrase PoCs.]
+
+## In Progress / Leads
+- [endpoints or ideas identified but not yet confirmed]
+
+## Next Steps
+1. [ordered concrete remaining work]
+
+Keep it concise but NEVER drop a confirmed finding or its PoC.`
+
+const summarizeUpdatePrompt = `The text in <previous-summary> is the cumulative summary so far. Below it is the execution trace of the LATEST round. Merge the new round into the summary.
+
+RULES:
+- PRESERVE every Confirmed Finding from the previous summary verbatim (type, URL, PoC, evidence). Never delete or shorten an existing PoC.
+- ADD newly confirmed findings from the latest round.
+- UPDATE Coverage: mark newly tested targets/subdomains.
+- UPDATE Next Steps based on what is now done.
+- If the latest round shows no new tool calls, keep the previous summary unchanged except possibly refining Next Steps.
+
+Output the FULL updated summary using the same EXACT format (## Goal / ## Coverage / ## Confirmed Findings / ## In Progress / Leads / ## Next Steps).`
+
+// Summarize folds the latest round's trace into a cumulative progress summary.
+// When previousSummary is empty it produces an initial summary; otherwise it
+// merges the new round into the existing one (pi-mono UPDATE pattern). This is
+// what lets the evaluator judge against everything accomplished so far rather
+// than a single round that may have produced no tool calls.
+func (e *Evaluator) Summarize(ctx context.Context, goal, previousSummary string, messages []provider.ChatMessage, output string, turns int) (string, error) {
+	trace := buildTrace(messages, output, turns)
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "## Goal\n%s\n\n", goal)
+	if strings.TrimSpace(previousSummary) != "" {
+		fmt.Fprintf(&sb, "<previous-summary>\n%s\n</previous-summary>\n\n", previousSummary)
+		fmt.Fprintf(&sb, "## Latest Round Execution Trace\n%s\n\n%s", trace, summarizeUpdatePrompt)
+	} else {
+		fmt.Fprintf(&sb, "## Execution Trace\n%s\n\n%s", trace, summarizeInitialPrompt)
+	}
+
+	resp, err := e.cfg.Provider.ChatCompletion(ctx, &provider.ChatCompletionRequest{
+		Model: e.cfg.Model,
+		Messages: []provider.ChatMessage{
+			provider.NewTextMessage("system", summarizeSystemPrompt),
+			provider.NewTextMessage("user", sb.String()),
+		},
+		MaxTokens: 4096,
+	})
+	if err != nil {
+		return previousSummary, fmt.Errorf("summarize LLM call: %w", err)
+	}
+	if len(resp.Choices) == 0 {
+		return previousSummary, fmt.Errorf("summarize: no choices returned")
+	}
+	content := resp.Choices[0].Message.Content
+	if content == nil || strings.TrimSpace(*content) == "" {
+		return previousSummary, fmt.Errorf("summarize: empty content")
+	}
+	return strings.TrimSpace(*content), nil
 }

--- a/pkg/agent/evaluator/evaluator_test.go
+++ b/pkg/agent/evaluator/evaluator_test.go
@@ -1,0 +1,41 @@
+package evaluator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chainreactors/aiscan/pkg/agent/provider"
+)
+
+func TestBuildTraceIncludesToolArgumentsAndResults(t *testing.T) {
+	result := `{"response_body":"iZj6c9ekljm6tiex6p8lnzZ\n","response_code":200,"target_url":"file:///etc/hostname"}`
+	messages := []provider.ChatMessage{
+		{
+			Role: "assistant",
+			ToolCalls: []provider.ToolCall{{
+				ID:   "call-1",
+				Type: "function",
+				Function: provider.FunctionCall{
+					Name:      "bash",
+					Arguments: `{"cmd":"curl -s -X POST https://desk.redhaze.top/api/desk/webhooks -d '{\"target_url\":\"file:///etc/hostname\"}'"}`,
+				},
+			}},
+		},
+		provider.NewToolResultMessage("call-1", result),
+	}
+
+	trace := buildTrace(messages, "confirmed", 2)
+
+	for _, want := range []string{
+		"Tool calls: 1",
+		"bash id=call-1",
+		"file:///etc/hostname",
+		`"response_code":200`,
+		`"target_url":"file:///etc/hostname"`,
+		"Final output:\nconfirmed",
+	} {
+		if !strings.Contains(trace, want) {
+			t.Fatalf("trace missing %q\ntrace:\n%s", want, trace)
+		}
+	}
+}

--- a/pkg/agent/evaluator/loop.go
+++ b/pkg/agent/evaluator/loop.go
@@ -28,16 +28,32 @@ func RunWithGoalEval(ctx context.Context, a *agent.Agent, cfg GoalLoopConfig) (*
 		return result, nil, err
 	}
 
+	// runningSummary accumulates confirmed work across all rounds (pi-mono
+	// UPDATE pattern). The evaluator judges against this cumulative view, so a
+	// round where the agent only replies without tool calls cannot erase the
+	// progress earlier rounds already established.
+	var runningSummary string
+
 	for attempt := 0; attempt < cfg.MaxEvalRounds; attempt++ {
 		if result.Stop != agent.StopReasonTerminated && result.Stop != agent.StopReasonCompleted {
 			return result, nil, nil
 		}
 
+		// Fold this round into the cumulative summary before judging.
+		if summary, sErr := cfg.Evaluator.Summarize(
+			ctx, cfg.Goal, runningSummary,
+			result.NewMessages, result.Output, result.Turns,
+		); sErr != nil {
+			cfg.Evaluator.cfg.Logger.Warnf("goal eval summarize error (round %d): %s", attempt+1, sErr)
+		} else {
+			runningSummary = summary
+		}
+
 		emitEvalEvent(cfg.Bus, agent.EventGoalEvalStart, attempt, nil)
 
 		verdict, evalErr := cfg.Evaluator.Evaluate(
-			ctx, cfg.Goal, cfg.Criteria,
-			result.Messages, result.Output, result.Turns,
+			ctx, cfg.Goal, cfg.Criteria, runningSummary,
+			result.NewMessages, result.Output, result.Turns,
 		)
 
 		if evalErr != nil {
@@ -60,8 +76,9 @@ func RunWithGoalEval(ctx context.Context, a *agent.Agent, cfg GoalLoopConfig) (*
 
 		feedback := verdict.Feedback
 		if feedback == "" {
-			feedback = fmt.Sprintf("Goal not achieved: %s. Please continue.", verdict.Reason)
+			feedback = fmt.Sprintf("Goal not achieved: %s.", verdict.Reason)
 		}
+		feedback += "\n\nContinue the work now by actually CALLING TOOLS (scan/curl/etc.) against the remaining targets. Do not just describe a plan or reply with text — perform the concrete next steps. The goal is not yet met."
 		cfg.Evaluator.cfg.Logger.Importantf("goal eval: injecting feedback (round %d): %s", attempt+1, feedback)
 
 		result, err = a.Run(ctx, feedback)


### PR DESCRIPTION
## 背景

`-e`(goal eval)模式下，evaluator 原来每轮只看「最新一轮」的执行 trace 来判定目标是否达成。当某一轮 agent 只回话、没有工具调用时，前几轮已确认的成果在评判者眼里被「清零」，导致反复打回、循环空转停不下来。

## 改动

引入**累积进度总结(cumulative progress summary)机制**：

- 新增 `Evaluator.Summarize`：按 pi-mono UPDATE 模式，把每轮 trace 折叠进一份持续累积的进度总结，强制保留所有已确认发现(类型 / URL / PoC / 证据)不被删改。
- `Evaluate` 增加 `summary` 参数，改为基于「所有轮次的累积进度」判定，而非单轮 trace。系统提示明确：最新一轮无工具调用但累积总结已有实质工作时，那些工作仍算数。
- `RunWithGoalEval`(`-e` 循环)每轮判定前先折叠累积总结再 Evaluate。
- 打回反馈措辞改为强制要求 agent 实际调用工具执行下一步，而非只描述计划。
- 增强 `buildTrace`：输出工具入参与结果，trace 上限提到 64k，按行截断。

## 测试

- `go build ./...` 通过
- `go test ./pkg/agent/evaluator/...` 通过
- 新增 `evaluator_test.go` 覆盖 buildTrace 输出工具入参与结果

## 范围

仅 3 个文件 / +216 / -18，全部在 `pkg/agent/evaluator/`。不含文档、部署脚本、配置改动。