### PR TITLE
fix(agent): 改进 LLM 重试机制（修复 429 限流即退出）

### DIFF
--- a/pkg/agent/provider/http.go
+++ b/pkg/agent/provider/http.go
@@ -81,7 +81,7 @@ func (r *apiRequest) do(ctx context.Context, method, endpoint string, body []byt
 		return nil, wrapReadError(parentCtx, callTimedOut.Load(), r.timeout, "read response", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, &APIError{StatusCode: resp.StatusCode, Message: string(data)}
+		return nil, &APIError{StatusCode: resp.StatusCode, Message: string(data), Header: resp.Header.Clone()}
 	}
 	return data, nil
 }
@@ -131,7 +131,7 @@ func streamSSE(
 		if readErr != nil {
 			return nil, wrapReadError(ctx, timedOut, timeout, "read response", readErr)
 		}
-		return nil, &APIError{StatusCode: resp.StatusCode, Message: string(respBody)}
+		return nil, &APIError{StatusCode: resp.StatusCode, Message: string(respBody), Header: resp.Header.Clone()}
 	}
 
 	var stallDetected atomic.Bool

--- a/pkg/agent/provider/types.go
+++ b/pkg/agent/provider/types.go
@@ -3,8 +3,8 @@ package provider
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
-
 )
 
 // CacheRetention controls prompt caching behavior across providers.
@@ -236,10 +236,11 @@ func (u *Usage) UnmarshalJSON(data []byte) error {
 }
 
 type APIError struct {
-	Message    string `json:"message"`
-	Type       string `json:"type"`
-	Code       string `json:"code"`
-	StatusCode int    `json:"-"`
+	Message    string      `json:"message"`
+	Type       string      `json:"type"`
+	Code       string      `json:"code"`
+	StatusCode int         `json:"-"`
+	Header     http.Header `json:"-"`
 }
 
 func (e *APIError) Error() string {
@@ -254,7 +255,7 @@ func (e *APIError) Error() string {
 
 func (e *APIError) IsRetryable() bool {
 	switch e.StatusCode {
-	case 429, 500, 502, 503, 529:
+	case 408, 409, 429, 500, 502, 503, 529:
 		return true
 	default:
 		return false

--- a/pkg/agent/retry.go
+++ b/pkg/agent/retry.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -17,6 +19,12 @@ type imageDisabler interface {
 }
 
 var errEmptyResponse = errors.New("empty response from LLM")
+
+const (
+	baseRetryDelay     = 500 * time.Millisecond
+	maxRetryDelay      = 32 * time.Second
+	retryJitterFactor  = 0.25
+)
 
 func isRetryableError(err error) bool {
 	if err == nil {
@@ -73,10 +81,65 @@ func isRetryableByMessage(err error) bool {
 	return false
 }
 
+// RetryDelay returns the backoff duration for the given attempt index (0-based).
+// It keeps the original conservative policy (1s·2^attempt, capped at 10s) for
+// backward compatibility with external callers such as runner and webagent
+// reconnect logic.
 func RetryDelay(attempt int) time.Duration {
 	delay := time.Second << uint(attempt)
 	if delay > 10*time.Second {
 		delay = 10 * time.Second
+	}
+	return delay
+}
+
+// retryDelayFor computes the backoff for an LLM call retry. It honors a
+// Retry-After header when the error carries one (server directive wins and
+// bypasses both the backoff formula and the cap); otherwise it falls back to
+// exponential backoff with additive jitter: min(base·2^attempt, maxDelay) + jitter.
+func retryDelayFor(attempt int, err error) time.Duration {
+	if after := retryAfterFromError(err); after > 0 {
+		return after
+	}
+	return computeRetryDelay(attempt, rand.Float64())
+}
+
+// retryAfterFromError parses a Retry-After header (integer seconds form) from
+// an APIError, if present. Returns 0 when absent or unparseable.
+func retryAfterFromError(err error) time.Duration {
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		return 0
+	}
+	if apiErr.Header == nil {
+		return 0
+	}
+	val := strings.TrimSpace(apiErr.Header.Get("Retry-After"))
+	if val == "" {
+		return 0
+	}
+	secs, perr := strconv.Atoi(val)
+	if perr != nil || secs < 0 {
+		return 0
+	}
+	return time.Duration(secs) * time.Second
+}
+
+// computeRetryDelay is the exponential backoff + additive jitter core used by
+// the LLM retry loop. Formula: min(baseRetryDelay·2^attempt, maxRetryDelay),
+// then add random jitter in [0, retryJitterFactor·delay).
+func computeRetryDelay(attempt int, jitterFrac float64) time.Duration {
+	if attempt < 0 {
+		attempt = 0
+	}
+	// baseDelay·2^attempt, capped at maxDelay
+	delay := baseRetryDelay << uint(attempt)
+	if delay > maxRetryDelay || delay <= 0 {
+		delay = maxRetryDelay
+	}
+	if jitterFrac > 0 {
+		// additive jitter: delay += random·[0, jitterFactor·delay)
+		delay += time.Duration(jitterFrac * retryJitterFactor * float64(delay))
 	}
 	return delay
 }
@@ -89,7 +152,7 @@ func requestWithRetry(ctx context.Context, cfg Config, bus emitter, messages []C
 	}
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		if attempt > 0 {
-			delay := RetryDelay(attempt - 1)
+			delay := retryDelayFor(attempt-1, lastErr)
 			cfg.Logger.Warnf("retrying LLM call (attempt %d/%d) after %s: %v", attempt+1, maxAttempts, delay, lastErr)
 			select {
 			case <-time.After(delay):

--- a/pkg/agent/retry_test.go
+++ b/pkg/agent/retry_test.go
@@ -3,8 +3,10 @@ package agent
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/chainreactors/aiscan/core/eventbus"
 	"github.com/chainreactors/aiscan/pkg/agent/provider"
@@ -377,5 +379,133 @@ func TestInferImageSupportModelRegistry(t *testing.T) {
 				t.Errorf("inferImageSupport(%q, %q) = %v, want %v", tt.provider, tt.model, got, tt.want)
 			}
 		})
+	}
+}
+
+// --- Backoff & Retry-After parsing tests ---
+
+func TestRetryDelayBackoffSequence(t *testing.T) {
+	// RetryDelay keeps the original conservative policy (1s·2^attempt, cap 10s)
+	// for backward compatibility with external callers (runner, webagent).
+	want := []time.Duration{
+		1 * time.Second,
+		2 * time.Second,
+		4 * time.Second,
+		8 * time.Second,
+		10 * time.Second, // cap reached
+		10 * time.Second, // stays capped
+	}
+	for i, w := range want {
+		if got := RetryDelay(i); got != w {
+			t.Errorf("attempt %d: RetryDelay = %s, want %s", i, got, w)
+		}
+	}
+}
+
+func TestComputeRetryDelaySequence(t *testing.T) {
+	// New LLM retry policy: 0.5s base, doubling, capped at 32s (no jitter here).
+	want := []time.Duration{
+		500 * time.Millisecond,
+		1 * time.Second,
+		2 * time.Second,
+		4 * time.Second,
+		8 * time.Second,
+		16 * time.Second,
+		32 * time.Second, // cap reached
+		32 * time.Second, // stays capped
+	}
+	for i, w := range want {
+		if got := computeRetryDelay(i, 0); got != w {
+			t.Errorf("attempt %d: computeRetryDelay = %s, want %s", i, got, w)
+		}
+	}
+}
+
+func TestRetryDelayJitterBounds(t *testing.T) {
+	// With jitter, delay must fall in [base, base + 0.25·base] (inclusive upper
+	// bound because jitterFrac can equal 1.0 in the test).
+	for attempt := 0; attempt < 8; attempt++ {
+		base := baseRetryDelay << uint(attempt)
+		if base > maxRetryDelay {
+			base = maxRetryDelay
+		}
+		upper := base + time.Duration(retryJitterFactor*float64(base))
+		for i := 0; i < 50; i++ {
+			got := computeRetryDelay(attempt, 1.0) // max jitter
+			if got < base || got > upper {
+				t.Errorf("attempt %d sample %d: got %s, want in [%s, %s]", attempt, i, got, base, upper)
+			}
+		}
+	}
+}
+
+func TestRetryAfterFromError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want time.Duration
+	}{
+		{
+			name: "seconds form",
+			err:  &APIError{StatusCode: 429, Header: http.Header{"Retry-After": []string{"30"}}},
+			want: 30 * time.Second,
+		},
+		{
+			name: "header absent",
+			err:  &APIError{StatusCode: 429},
+			want: 0,
+		},
+		{
+			name: "non-integer",
+			err:  &APIError{StatusCode: 429, Header: http.Header{"Retry-After": []string{"Wed, 21 Oct 2015 07:28:00 GMT"}}},
+			want: 0,
+		},
+		{
+			name: "wrapped APIError",
+			err:  fmt.Errorf("call failed: %w", &APIError{StatusCode: 429, Header: http.Header{"Retry-After": []string{"5"}}}),
+			want: 5 * time.Second,
+		},
+		{
+			name: "non-APIError",
+			err:  fmt.Errorf("plain error"),
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := retryAfterFromError(tt.err); got != tt.want {
+				t.Errorf("retryAfterFromError() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRetryDelayForHonorsRetryAfter(t *testing.T) {
+	err := &APIError{StatusCode: 429, Header: http.Header{"Retry-After": []string{"60"}}}
+	// Retry-After bypasses both the formula and the 32s cap.
+	if got := retryDelayFor(0, err); got != 60*time.Second {
+		t.Errorf("retryDelayFor with Retry-After=60 = %s, want 60s", got)
+	}
+}
+
+func TestRetryDelayForFallsBackToBackoffWhenNoHeader(t *testing.T) {
+	err := &APIError{StatusCode: 500} // no Header
+	got := retryDelayFor(2, err)
+	// attempt 2 base = 2s; with jitter it must stay in [2s, 2.5s)
+	if got < 2*time.Second || got >= 2500*time.Millisecond {
+		t.Errorf("retryDelayFor(attempt=2, no header) = %s, want in [2s, 2.5s)", got)
+	}
+}
+
+func TestIsRetryableNowIncludes408409(t *testing.T) {
+	for _, code := range []int{408, 409, 429, 500, 502, 503, 529} {
+		if !isRetryableError(&APIError{StatusCode: code}) {
+			t.Errorf("status %d should be retryable", code)
+		}
+	}
+	for _, code := range []int{400, 401, 403, 404} {
+		if isRetryableError(&APIError{StatusCode: code}) {
+			t.Errorf("status %d should NOT be retryable", code)
+		}
 	}
 }

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -232,7 +232,7 @@ func (c Config) init() Config {
 	if c.Logger == nil {
 		c.Logger = telemetry.NopLogger()
 	}
-	if c.MaxRetries < 0 {
+	if c.MaxRetries <= 0 {
 		c.MaxRetries = DefaultMaxRetries
 	}
 	if c.MaxResultSize <= 0 {


### PR DESCRIPTION
## 背景

实际使用中遇到 LLM API 返回 429（RPM 限流）时，agent 直接报错退出，无法自动恢复：

```
[agent error | turns=6 | err="LLM stream failed at turn 6: API error (429): 请求已超过帐户模型 RPM 限制"]
```

排查后发现重试机制存在一个致命 bug + 几个可改进点。

## 根因

`pkg/agent/types.go` 的 `Config.init()` 中：

```go
if c.MaxRetries < 0 {   // 只有 < 0 才用默认值
    c.MaxRetries = DefaultMaxRetries
}
```

而 `core/runner/runner.go` 构造 `agent.Config{}` 时未设置 `MaxRetries` 字段，零值 `0` 不触发默认值兜底 → `maxAttempts = 0 + 1 = 1` → **429 时仅尝试 1 次就退出**。名义上配置了 9 次重试，实际为 0 次。

## 改动内容

### 1. 修复 MaxRetries 默认值 bug
`< 0` → `<= 0`，零值时正确使用 `DefaultMaxRetries`(9)。

### 2. 改进退避策略（参考 Claude Code 设计）
| | 改前 | 改后 |
|---|---|---|
| 基数 | 1s | 0.5s |
| 公式 | 1s·2^n | 0.5s·2^n |
| 封顶 | 10s | 32s |
| 抖动 | 无 | 加性 +25% additive jitter |

旧的 10s 封顶对 RPM 限流（通常需等 30~60s 窗口恢复）几乎无效；无 jitter 在多 agent 并发时会惊群。

### 3. 支持 Retry-After 头
- `APIError` 新增 `Header http.Header` 字段，在 `http.go` 两处构造点从 `resp.Header.Clone()` 填充
- 重试时优先使用服务器返回的 `Retry-After`（整数秒），绕过退避公式与封顶

### 4. 扩展可重试状态码
`IsRetryable()` 新增 408（Request Timeout）和 409（Conflict）。

## 非破坏性

- `RetryDelay()` 公开函数**保持原行为**（1s·2^n，封顶 10s），`runner.go` / `webagent` 等外部调用方完全不受影响
- 新退避策略仅由 LLM 重试循环内部使用（`retryDelayFor` / `computeRetryDelay`）

## 测试

新增/修改的测试用例（`pkg/agent/retry_test.go`）：
- `TestRetryDelayBackoffSequence` - 验证 `RetryDelay` 保持原行为
- `TestComputeRetryDelaySequence` - 验证新退避序列（0.5s → 32s）
- `TestRetryDelayJitterBounds` - 验证 jitter 边界 `[base, base·1.25]`
- `TestRetryAfterFromError` - 验证 Retry-After 解析（秒/Header 缺失/非整数/wrapped error）
- `TestRetryDelayForHonorsRetryAfter` - 验证 Retry-After 绕过封顶
- `TestIsRetryableNowIncludes408409` - 验证可重试状态码扩展

```
$ go test ./pkg/agent/...
ok  github.com/chainreactors/aiscan/pkg/agent
```

## 检查清单

- [x] 已运行 `go build ./pkg/agent/` 通过
- [x] 已运行 `go test ./pkg/agent/...` 全部通过
- [x] 公开 API `RetryDelay` 保持向后兼容
- [x] 改动仅限 `pkg/agent/` 和 `pkg/agent/provider/`
