### PR TITLE
fix(build): restore static native RE2 for full artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -542,7 +542,7 @@ jobs:
           [[ "${{ matrix.goos }}" == "windows" ]] && suffix=".exe"
           CGO_ENABLED=1 GOOS="${{ matrix.goos }}" GOARCH="${{ matrix.goarch }}" \
             go build -trimpath \
-            -tags "forceposix emptytemplates noembed osusergo netgo full sqlite" \
+            -tags "forceposix emptytemplates noembed osusergo netgo full sqlite re2_cgo re2_static" \
             -ldflags "-s -w" -buildvcs=false \
             -o "dist/full_${{ matrix.goos }}_${{ matrix.goarch }}${suffix}" ./cmd/aiscan
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,12 +225,12 @@ jobs:
         run: echo "C:/msys64/mingw64/bin" >> "$GITHUB_PATH"
 
       - name: Run native Windows package tests
-        run: go test -count=1 ./agent/... ./pkg/runner/... ./pkg/web/...
+        run: go test -count=1 -tags "re2_cgo re2_static" ./agent/... ./pkg/runner/... ./pkg/web/...
         env:
           CGO_ENABLED: "1"
 
       - name: Compile and test the full CLI on Windows
-        run: go test -count=1 -tags full ./cmd/aiscan
+        run: go test -count=1 -tags "forceposix emptytemplates noembed osusergo netgo full sqlite re2_cgo re2_static" ./cmd/aiscan
         env:
           CGO_ENABLED: "1"
 
@@ -463,11 +463,15 @@ jobs:
           for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64; do
             IFS='/' read -r goos goarch <<< "$target"
             echo "  compile ${goos}/${goarch}"
+            suffix=""
+            [[ "$goos" == "windows" ]] && suffix=".exe"
             CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
               go build -trimpath -tags "forceposix emptytemplates noembed osusergo netgo" \
               -ldflags "-s -w" -buildvcs=false \
-              -o "dist/standard_${goos}_${goarch}" ./cmd/aiscan
+              -o "dist/standard_${goos}_${goarch}${suffix}" ./cmd/aiscan
           done
+          test -f dist/standard_windows_amd64.exe
+          test -f dist/standard_windows_arm64.exe
           ls -lh dist/
 
       - name: Upload standard binaries

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -138,7 +138,7 @@ jobs:
             runner: ubuntu-22.04
             main: ./cmd/aiscan
             binary: aiscan-full
-            tags: "forceposix emptytemplates noembed osusergo netgo full sqlite"
+            tags: "forceposix emptytemplates noembed osusergo netgo full sqlite re2_cgo re2_static"
             targets: "linux/amd64"
             cgo: "1"
           - id: aiscan-full-linux-arm64
@@ -146,7 +146,7 @@ jobs:
             runner: ubuntu-24.04-arm
             main: ./cmd/aiscan
             binary: aiscan-full
-            tags: "forceposix emptytemplates noembed osusergo netgo full sqlite"
+            tags: "forceposix emptytemplates noembed osusergo netgo full sqlite re2_cgo re2_static"
             targets: "linux/arm64"
             cgo: "1"
           - id: aiscan-full-darwin-amd64
@@ -154,7 +154,7 @@ jobs:
             runner: macos-15-intel
             main: ./cmd/aiscan
             binary: aiscan-full
-            tags: "forceposix emptytemplates noembed osusergo netgo full sqlite"
+            tags: "forceposix emptytemplates noembed osusergo netgo full sqlite re2_cgo re2_static"
             targets: "darwin/amd64"
             cgo: "1"
           - id: aiscan-full-darwin-arm64
@@ -162,7 +162,7 @@ jobs:
             runner: macos-15
             main: ./cmd/aiscan
             binary: aiscan-full
-            tags: "forceposix emptytemplates noembed osusergo netgo full sqlite"
+            tags: "forceposix emptytemplates noembed osusergo netgo full sqlite re2_cgo re2_static"
             targets: "darwin/arm64"
             cgo: "1"
           - id: aiscan-full-windows-amd64
@@ -170,7 +170,7 @@ jobs:
             runner: windows-2022
             main: ./cmd/aiscan
             binary: aiscan-full
-            tags: "forceposix emptytemplates noembed osusergo netgo full sqlite"
+            tags: "forceposix emptytemplates noembed osusergo netgo full sqlite re2_cgo re2_static"
             targets: "windows/amd64"
             cgo: "1"
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,6 +66,8 @@ builds:
       - netgo
       - full
       - sqlite
+      - re2_cgo
+      - re2_static
     ldflags:
       - -s -w -X github.com/chainreactors/aiscan/core/config.Version={{.Version}}
     asmflags:

--- a/core/resources/resources_test.go
+++ b/core/resources/resources_test.go
@@ -64,6 +64,31 @@ func TestInitUsesAiscanEmbeddedResources(t *testing.T) {
 	}
 }
 
+func TestEmbeddedFingersMatchNginx(t *testing.T) {
+	set, err := Init(context.Background(), Options{})
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	if set.Fingers != nil {
+		t.Cleanup(func() { _ = set.Fingers.Close() })
+	}
+	if set.Neutron != nil {
+		t.Cleanup(func() { _ = set.Neutron.Close() })
+	}
+
+	raw := []byte("HTTP/1.1 200 OK\r\nServer: nginx/1.24.0\r\nContent-Type: text/html\r\n\r\n<html><body>Welcome to nginx!</body></html>")
+	frameworks, err := set.Fingers.Match(raw)
+	if err != nil {
+		t.Fatalf("Match() error = %v", err)
+	}
+	for _, name := range frameworks.GetNames() {
+		if strings.Contains(strings.ToLower(name), "nginx") {
+			return
+		}
+	}
+	t.Fatalf("nginx fingerprint not matched: %v", frameworks.GetNames())
+}
+
 // TestPipelineDeliversAiscanBytes ensures that the bytes aiscan stages in
 // gogoConfigs / sprayConfigs / zombieConfigs really arrive at the downstream
 // SDK's pkg.LoadConfig — the actual call site each engine uses to read its

--- a/go.mod
+++ b/go.mod
@@ -329,6 +329,6 @@ require (
 
 replace github.com/projectdiscovery/katana => github.com/chainreactors/katana v1.6.2-0.20260716115809-46dd3ac126d2
 
-replace github.com/wasilibs/go-re2 => github.com/chainreactors/go-re2 v1.11.1-0.20260718064805-1d8511959320
+replace github.com/wasilibs/go-re2 => github.com/chainreactors/go-re2 v1.11.1-0.20260803043001-2e8338def4c6
 
 replace github.com/chainreactors/aiscan/aop => ./aop

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/chainreactors/files v0.0.0-20240716182835-7884ee1e77f0 h1:cU3sGEODXZs
 github.com/chainreactors/files v0.0.0-20240716182835-7884ee1e77f0/go.mod h1:NSxGNMRWryAyrDzZpVwmujI22wbGw6c52bQOd5zEvyU=
 github.com/chainreactors/fingers v1.2.2-0.20260714063144-070758342f45 h1:wIKAvAPjQUXqAKDYG0UnpLTwn/+fwT7ipwFgNPxz88M=
 github.com/chainreactors/fingers v1.2.2-0.20260714063144-070758342f45/go.mod h1:ba7u/7/I9yV7TvuWj+VV9QYz9NmlLdh6UK9kxRRft+E=
-github.com/chainreactors/go-re2 v1.11.1-0.20260718064805-1d8511959320 h1:gkcY9PramU2ZQZ9NWisdog4oMKaeNsd30er6Nr1pKvE=
-github.com/chainreactors/go-re2 v1.11.1-0.20260718064805-1d8511959320/go.mod h1:4qC68vqWSuPTct3spuTrWBqCpm00mQ707JKLS1izVjI=
+github.com/chainreactors/go-re2 v1.11.1-0.20260803043001-2e8338def4c6 h1:FwRFQILG9Q7N4pQ6uSSKEKwMNbea5WcOIscGfj3qaUY=
+github.com/chainreactors/go-re2 v1.11.1-0.20260803043001-2e8338def4c6/go.mod h1:4qC68vqWSuPTct3spuTrWBqCpm00mQ707JKLS1izVjI=
 github.com/chainreactors/gogo/v2 v2.15.1-0.20260728051744-a278b33d8744 h1:5Bj73ddSftvWEgjo3dEOUis1CuwPaX8JsSAIZCujfxE=
 github.com/chainreactors/gogo/v2 v2.15.1-0.20260728051744-a278b33d8744/go.mod h1:Em8DiV1Rh59FCd9zN4RQBi3RnUt9yPWD/oxPEPTyXIk=
 github.com/chainreactors/ioa v0.1.2-0.20260802104212-d0e2604a2186 h1:oKM8D7wYAl8k9zEpFVb7TOyeHmVvvxhKZE7qxvGd39U=


### PR DESCRIPTION
## Summary

- upgrade the `chainreactors/go-re2` replacement to the revision with static native RE2 support
- build every `aiscan-full` release target and GoReleaser artifact with `re2_cgo re2_static`
- exercise the Windows native packages and full CLI with the same release tags
- give standard Windows artifacts an explicit `.exe` suffix and verify both Windows outputs exist
- add an embedded nginx fingerprint smoke test to catch RE2/resource regressions

## Why

Full release artifacts should use the native RE2 backend without requiring a shared RE2 library at runtime. The CI checks keep the release tags aligned with the tested Windows build and make Windows artifact names deterministic.

## Verification

- `go mod tidy -diff`
- `go test -count=1 ./core/resources`
- `go test -count=1 ./cmd/aiscan`
- `CGO_ENABLED=1 go test -count=1 -tags "re2_cgo re2_static" ./agent/... ./pkg/runner/... ./pkg/web/...`
- `CGO_ENABLED=1 go test -count=1 -tags "forceposix emptytemplates noembed osusergo netgo full sqlite re2_cgo re2_static" ./cmd/aiscan`