### PR TITLE
修复 Runner 工具输出非法 UTF-8 导致 terminal 丢失

### DIFF
--- a/pkg/runner/tool_call.go
+++ b/pkg/runner/tool_call.go
@@ -53,6 +53,7 @@ func ExecuteToolRequest(ctx context.Context, operationID string, request *toolpb
 	result.CallId = call.Id
 	result.Name = call.Name
 	result.DurationMs = uint64(time.Since(started).Milliseconds())
+	sanitizeToolResultUTF8(result)
 	return &aop.Event{
 		Id: runtimeEnvelopeID(), EmittedAt: timestamppb.Now(), SessionId: request.SessionId,
 		TurnId: request.TurnId, Emitter: "aiscan.agent", Payload: &aop.Event_ToolResult{ToolResult: result},
@@ -111,7 +112,7 @@ func (s *progressStreamer) Write(p []byte) {
 			}
 			return
 		}
-		line := string(s.buf[:idx])
+		line := sanitizeUTF8(string(s.buf[:idx]))
 		s.buf = s.buf[idx+1:]
 		s.emit(line)
 	}
@@ -121,9 +122,42 @@ func (s *progressStreamer) Flush() {
 	if s.bus == nil || len(s.buf) == 0 {
 		return
 	}
-	data := string(s.buf)
+	data := sanitizeUTF8(string(s.buf))
 	s.buf = s.buf[:0]
 	s.emit(data)
+}
+
+func sanitizeUTF8(value string) string {
+	return strings.ToValidUTF8(value, "\uFFFD")
+}
+
+// sanitizeToolResultUTF8 protects the AOP boundary from arbitrary command
+// bytes and tools that construct protobuf content directly.
+func sanitizeToolResultUTF8(result *aop.ToolResult) {
+	if result == nil {
+		return
+	}
+	result.CallId = sanitizeUTF8(result.CallId)
+	result.Name = sanitizeUTF8(result.Name)
+	for _, content := range result.Output {
+		if content == nil {
+			continue
+		}
+		switch value := content.Value.(type) {
+		case *aop.Content_Text:
+			if value.Text != nil {
+				value.Text.Text = sanitizeUTF8(value.Text.Text)
+			}
+		case *aop.Content_Reasoning:
+			if value.Reasoning != nil {
+				value.Reasoning.Text = sanitizeUTF8(value.Reasoning.Text)
+			}
+		case *aop.Content_Refusal:
+			value.Refusal = sanitizeUTF8(value.Refusal)
+		case *aop.Content_ToolResult:
+			sanitizeToolResultUTF8(value.ToolResult)
+		}
+	}
 }
 
 func (s *progressStreamer) emit(line string) {

--- a/pkg/runner/tool_call_test.go
+++ b/pkg/runner/tool_call_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	aop "github.com/chainreactors/aiscan/aop"
 	toolpb "github.com/chainreactors/aiscan/aop/tool"
@@ -134,6 +135,59 @@ func TestExecuteToolRequestForeground(t *testing.T) {
 	result := event.GetToolResult()
 	if result.IsError || result.Output[0].GetText().Text != "streamed" {
 		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestProgressStreamerSanitizesInvalidUTF8(t *testing.T) {
+	progressBus := eventbus.New[*toolpb.Progress]()
+	var progress []*toolpb.Progress
+	progressBus.Subscribe(func(event *toolpb.Progress) {
+		progress = append(progress, event)
+	})
+	stream := newProgressStreamer(progressBus, "bash", "task-invalid")
+	stream.Write([]byte{'o', 'k', 0xff, '\n'})
+	stream.Write([]byte{0xe4, 0xbd})
+	stream.Write([]byte{0xa0, '\n'})
+	stream.Flush()
+
+	if len(progress) != 2 {
+		t.Fatalf("progress count = %d", len(progress))
+	}
+	if progress[0].Text != "ok\uFFFD" || progress[1].Text != "\u4f60" {
+		t.Fatalf("progress = %#v", progress)
+	}
+	for _, item := range progress {
+		if !utf8.ValidString(item.Text) {
+			t.Fatalf("progress is not valid UTF-8: %q", item.Text)
+		}
+		message := &toolpb.ProtocolMessage{Message: &toolpb.ProtocolMessage_Progress{Progress: item}}
+		if _, err := aop.Wrap("progress", item.CallId, message); err != nil {
+			t.Fatalf("wrap progress: %v", err)
+		}
+	}
+}
+
+type invalidTextResultExecutor struct{}
+
+func (invalidTextResultExecutor) ExecuteTool(context.Context, string, string) (*tool.Result, error) {
+	invalid := string([]byte{'r', 0xff, 's'})
+	return &tool.Result{Output: []*aop.Content{{
+		Value: &aop.Content_Text{Text: &aop.TextContent{Text: invalid}},
+	}}}, nil
+}
+
+func TestExecuteToolRequestSanitizesDirectToolResultText(t *testing.T) {
+	event, err := ExecuteToolRequest(context.Background(), "call-invalid", toolRequest(t, "call-invalid", "scan", nil), invalidTextResultExecutor{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := event.GetToolResult().GetOutput()[0].GetText().GetText()
+	if text != "r\uFFFDs" || !utf8.ValidString(text) {
+		t.Fatalf("result text = %q", text)
+	}
+	message := &aop.ProtocolMessage{Message: &aop.ProtocolMessage_Event{Event: event}}
+	if _, err := aop.Wrap("event", "call-invalid", message); err != nil {
+		t.Fatalf("wrap result event: %v", err)
 	}
 }
 


### PR DESCRIPTION
## 问题

Runner 工具和 PTY 输出本质上是任意字节。此前 `progressStreamer` 会直接把原始 `[]byte` 转成 protobuf `string`，工具最终结果也没有统一校验。遇到 `0xff` 等非法 UTF-8 时，`aop.Wrap` 编码失败，消息会被丢弃；若丢失的是 terminal ToolResult，上游调用会一直等待到超时。

## 修复

- Progress 在按行发送和最终 Flush 时统一使用 `strings.ToValidUTF8`。
- `ExecuteToolRequest` 返回 terminal event 前，递归清洗 CallId、Name、text、reasoning、refusal 以及嵌套 ToolResult。
- 合法 UTF-8 内容保持不变，非法字节以替换字符降级，保证 AOP 消息始终可编码。
- 增加非法孤立字节、跨 chunk 多字节字符和嵌套终态字段的回归测试。

## 验证

- `go test ./pkg/runner ./pkg/node`
- `go test -race ./pkg/runner ./pkg/node`