### PR TITLE
docs(skills): correct gogo/scan port presets (top100/top1000 invalid)

### DIFF
--- a/skills/aiscan/okf/easm/gogo.md
+++ b/skills/aiscan/okf/easm/gogo.md
@@ -22,17 +22,17 @@ Capabilities:
 Common usage:
 
 ```bash
-gogo -i 10.0.0.1 -p top100
+gogo -i 10.0.0.1 -p top2
 gogo -i 10.0.0.0/24 -p 80,443,8080
 gogo -i 10.0.0.1,10.0.0.2 -p all
-gogo -l /tmp/targets.txt -p top100
+gogo -l /tmp/targets.txt -p top2
 ```
 
 Notes:
 
 - `-i` accepts IP, CIDR, or comma-separated IPs. **NOT** `ip:port` — bare `10.0.0.1:8080` will fail with "Parse IP Failed". Use `-i 10.0.0.1 -p 8080` instead.
 - `-l` reads a target file (one IP/CIDR per line).
-- `-p` is gogo ports (`top100`, `top1000`, `all`, `-` for all 65535, or `80,443,8080`).
+- `-p` is gogo ports: presets `top1` / `top2` / `top3` (default `top1`, widening coverage), `all` (every preset port), `-` for all 65535, ranges like `10000-10100`, or explicit `80,443,8080`. An unknown name such as `top100` / `top1000` is treated as a literal port and fails with `unknown port` — run `gogo -P port` to list every preset.
 - Fingerprints and vuln hints are evidence leads; user intent decides whether to summarize, analyze, verify, compare, or plan follow-up work.
 
 ## Related concepts

--- a/skills/aiscan/okf/easm/scan.md
+++ b/skills/aiscan/okf/easm/scan.md
@@ -26,7 +26,7 @@ Common usage:
 scan -i 10.0.0.1 --mode quick
 scan -i 10.0.0.0/24 --mode full
 scan -i 10.0.0.1:8080 --mode quick
-scan -i 10.0.0.1 --mode full --ports top1000
+scan -i 10.0.0.1 --mode full --ports top3
 scan -i http://10.0.0.1:8080 --mode quick
 scan -i https://example.com --mode quick
 


### PR DESCRIPTION
## Problem

The `gogo` and `scan` playbooks tell the agent to use `-p top100` / `--ports top1000`, but gogo has **no** `top100` / `top1000` preset. Its port presets are `top1` / `top2` / `top3` (default `top1`; see `core/options.go` and `pkg/config.go`).

When an unknown name is passed, `PortPreset.ChoicePort` (chainreactors/utils `port.go`) falls through to `return []string{portname}`, so gogo treats `top100` as a **literal port**, runs `net.LookupPort("tcp", "top100")` → `unknown port`, and scans **only 1 port**:

```
[debug] <ip>:top100 stat: open, errmsg: dial tcp: lookup tcp/top100: unknown port
[*] Start task <ip> , total ports: 1 , mod: default
```

Hit in production: an agent followed `gogo.md`'s `-p top100` and unknowingly scanned a single port instead of the intended set.

## Fix

- **`gogo.md`**: `-p top100` → `-p top2`; rewrite the `-p` note to list the real accepted forms (`top1`/`top2`/`top3`, `all`, `-`, ranges, explicit ports) and warn that unknown names fail with `unknown port`.
- **`scan.md`**: `--ports top1000` → `--ports top3` (`--ports` is forwarded straight to gogo, so the same constraint applies).

`all` and `-` are left unchanged — both are valid (`ChoicePort` special-cases `all`; `-` expands to `1-65535`).

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
