### PR TITLE
fix(toolargs): 在 artifact 唯一出生点封顶,避免超大扫描记录撑爆控制面帧

### DIFF
--- a/tools/toolargs/artifact_budget.go
+++ b/tools/toolargs/artifact_budget.go
@@ -1,0 +1,87 @@
+package toolargs
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// A control plane delivers one artifact event as one frame and bounds a frame:
+// past its limit the frame is dropped, and past a hard limit the transport
+// closes the connection outright — taking every other tool call sharing it down
+// with it. A scanner-native record is the one artifact with no natural bound: a
+// single katana crawl result carries the response body next to the raw
+// transcript of that same response, and katana's own body ceiling alone is 4
+// MiB, so one record can reach eight to ten.
+//
+// This is the sole place an artifact is built (every tool reaches the wire
+// through EmitArtifactResultCtx), and the record is structured JSON here, before
+// it becomes opaque bytes downstream. So it is bounded here: at birth, where the
+// bulk can be cut from the body and transcript while the small fields a control
+// plane projects — URL, host, port, status, technology — are kept intact, and
+// where no record is ever lost, only trimmed. A downstream frame guard, working
+// from bytes it cannot parse, could only drop the whole record.
+const (
+	maxArtifactDataBytes   = 4 << 20
+	maxArtifactStringBytes = 64 << 10
+)
+
+// boundArtifactData returns data unchanged when it is within budget, and
+// otherwise a copy of the record with its oversized strings truncated. data is
+// the output of json.Marshal, so it always parses; the guard on the decode error
+// is defensive. The returned bytes are never nil and never longer than the input
+// — a pathological record that stays over budget after the tightest pass is sent
+// as-is-but-smaller for the frame guard to bound, never dropped here.
+func boundArtifactData(data []byte) []byte {
+	if len(data) <= maxArtifactDataBytes {
+		return data
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var record any
+	if err := decoder.Decode(&record); err != nil {
+		return data
+	}
+	var last []byte
+	for _, limit := range []int{maxArtifactStringBytes, 8 << 10, 512} {
+		shrunk, err := json.Marshal(truncatedStrings(record, limit))
+		if err != nil {
+			return data
+		}
+		last = shrunk
+		if len(shrunk) <= maxArtifactDataBytes {
+			return shrunk
+		}
+	}
+	return last
+}
+
+// truncatedStrings copies value with every string longer than limit truncated.
+// It copies instead of mutating so a tighter pass starts from the untouched
+// record rather than re-truncating its own markers, keeps numbers as their
+// original text (UseNumber) so a re-encode cannot round a port or an id, and
+// drops the partial rune a byte cut leaves behind — an artifact that is not
+// valid UTF-8 fails to marshal further down the pipeline.
+func truncatedStrings(value any, limit int) any {
+	switch typed := value.(type) {
+	case string:
+		if len(typed) <= limit {
+			return typed
+		}
+		return strings.ToValidUTF8(typed[:limit], "") + fmt.Sprintf("…[aiscan: truncated, %d bytes total]", len(typed))
+	case []any:
+		items := make([]any, len(typed))
+		for i, item := range typed {
+			items[i] = truncatedStrings(item, limit)
+		}
+		return items
+	case map[string]any:
+		fields := make(map[string]any, len(typed))
+		for name, item := range typed {
+			fields[name] = truncatedStrings(item, limit)
+		}
+		return fields
+	}
+	return value
+}

--- a/tools/toolargs/artifact_budget.go
+++ b/tools/toolargs/artifact_budget.go
@@ -4,84 +4,352 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"sort"
 	"strings"
 )
 
 // A control plane delivers one artifact event as one frame and bounds a frame:
 // past its limit the frame is dropped, and past a hard limit the transport
-// closes the connection outright — taking every other tool call sharing it down
+// closes the connection outright -- taking every other tool call sharing it down
 // with it. A scanner-native record is the one artifact with no natural bound: a
 // single katana crawl result carries the response body next to the raw
 // transcript of that same response, and katana's own body ceiling alone is 4
 // MiB, so one record can reach eight to ten.
 //
-// This is the sole place an artifact is built (every tool reaches the wire
-// through EmitArtifactResultCtx), and the record is structured JSON here, before
-// it becomes opaque bytes downstream. So it is bounded here: at birth, where the
-// bulk can be cut from the body and transcript while the small fields a control
-// plane projects — URL, host, port, status, technology — are kept intact, and
-// where no record is ever lost, only trimmed. A downstream frame guard, working
-// from bytes it cannot parse, could only drop the whole record.
+// EmitArtifactResultCtx is the sole place a scanner artifact is built, and the
+// record is still structured JSON there. Oversized records are therefore
+// encoded under a hard budget at that boundary. Projection fields are emitted
+// first, body/transcript fields last, and each child value receives its own
+// budget so one collection cannot crowd every useful field out of the record.
 const (
-	maxArtifactDataBytes   = 4 << 20
-	maxArtifactStringBytes = 64 << 10
+	maxArtifactDataBytes           = 4 << 20
+	maxArtifactStringBytes         = 64 << 10
+	maxArtifactProjectedValueBytes = 512 << 10
+	maxArtifactOtherValueBytes     = 256 << 10
+	maxArtifactJSONDepth           = 128
+	artifactBudgetMetadataField    = "_aiscan_artifact"
 )
 
-// boundArtifactData returns data unchanged when it is within budget, and
-// otherwise a copy of the record with its oversized strings truncated. data is
-// the output of json.Marshal, so it always parses; the guard on the decode error
-// is defensive. The returned bytes are never nil and never longer than the input
-// — a pathological record that stays over budget after the tightest pass is sent
-// as-is-but-smaller for the frame guard to bound, never dropped here.
+// boundArtifactData returns data byte-for-byte when it is within budget. An
+// oversized record is decoded with UseNumber, then deterministically re-encoded
+// under maxArtifactDataBytes. The result is always non-nil, valid JSON, shorter
+// than the oversized input, and no larger than the hard budget.
 func boundArtifactData(data []byte) []byte {
 	if len(data) <= maxArtifactDataBytes {
 		return data
 	}
+
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.UseNumber()
 	var record any
 	if err := decoder.Decode(&record); err != nil {
-		return data
+		return artifactBudgetFallback(len(data))
 	}
-	var last []byte
-	for _, limit := range []int{maxArtifactStringBytes, 8 << 10, 512} {
-		shrunk, err := json.Marshal(truncatedStrings(record, limit))
-		if err != nil {
-			return data
-		}
-		last = shrunk
-		if len(shrunk) <= maxArtifactDataBytes {
-			return shrunk
-		}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return artifactBudgetFallback(len(data))
 	}
-	return last
+
+	bounded, ok := marshalBoundedArtifactValue(
+		markArtifactTruncated(record, len(data)),
+		maxArtifactDataBytes,
+		0,
+	)
+	if !ok || len(bounded) > maxArtifactDataBytes || !json.Valid(bounded) {
+		return artifactBudgetFallback(len(data))
+	}
+	return bounded
 }
 
-// truncatedStrings copies value with every string longer than limit truncated.
-// It copies instead of mutating so a tighter pass starts from the untouched
-// record rather than re-truncating its own markers, keeps numbers as their
-// original text (UseNumber) so a re-encode cannot round a port or an id, and
-// drops the partial rune a byte cut leaves behind — an artifact that is not
-// valid UTF-8 fails to marshal further down the pipeline.
-func truncatedStrings(value any, limit int) any {
-	switch typed := value.(type) {
-	case string:
-		if len(typed) <= limit {
-			return typed
-		}
-		return strings.ToValidUTF8(typed[:limit], "") + fmt.Sprintf("…[aiscan: truncated, %d bytes total]", len(typed))
-	case []any:
-		items := make([]any, len(typed))
-		for i, item := range typed {
-			items[i] = truncatedStrings(item, limit)
-		}
-		return items
-	case map[string]any:
-		fields := make(map[string]any, len(typed))
-		for name, item := range typed {
-			fields[name] = truncatedStrings(item, limit)
-		}
-		return fields
+func markArtifactTruncated(record any, originalBytes int) any {
+	metadata := map[string]any{
+		"limit_bytes":    maxArtifactDataBytes,
+		"original_bytes": originalBytes,
+		"truncated":      true,
 	}
-	return value
+	if fields, ok := record.(map[string]any); ok {
+		marked := make(map[string]any, len(fields)+1)
+		for name, value := range fields {
+			marked[name] = value
+		}
+		marked[artifactBudgetMetadataField] = metadata
+		return marked
+	}
+	return map[string]any{
+		artifactBudgetMetadataField: metadata,
+		"value":                     record,
+	}
+}
+
+func artifactBudgetFallback(originalBytes int) []byte {
+	data, _ := json.Marshal(map[string]any{
+		artifactBudgetMetadataField: map[string]any{
+			"limit_bytes":     maxArtifactDataBytes,
+			"original_bytes":  originalBytes,
+			"payload_omitted": true,
+			"truncated":       true,
+		},
+	})
+	return data
+}
+
+// marshalBoundedArtifactValue emits one complete JSON value within limit. Maps
+// sort projection keys ahead of ordinary data and bulk fields; arrays retain
+// their original order. A root-level metadata field records that some of the
+// original representation was omitted.
+func marshalBoundedArtifactValue(value any, limit, depth int) ([]byte, bool) {
+	if limit <= 0 {
+		return nil, false
+	}
+	if depth >= maxArtifactJSONDepth {
+		if limit < len("null") {
+			return nil, false
+		}
+		return []byte("null"), true
+	}
+
+	switch typed := value.(type) {
+	case nil:
+		if limit < len("null") {
+			return nil, false
+		}
+		return []byte("null"), true
+	case bool:
+		raw, _ := json.Marshal(typed)
+		if len(raw) > limit {
+			return nil, false
+		}
+		return raw, true
+	case json.Number:
+		raw := []byte(typed.String())
+		if len(raw) > limit {
+			return nil, false
+		}
+		return raw, true
+	case string:
+		return marshalBoundedArtifactString(typed, min(limit, maxArtifactStringBytes))
+	case []any:
+		return marshalBoundedArtifactArray(typed, limit, depth+1)
+	case map[string]any:
+		return marshalBoundedArtifactMap(typed, limit, depth+1)
+	default:
+		raw, err := json.Marshal(typed)
+		if err != nil || len(raw) > limit {
+			return nil, false
+		}
+		return raw, true
+	}
+}
+
+func marshalBoundedArtifactString(value string, limit int) ([]byte, bool) {
+	if limit < 2 {
+		return nil, false
+	}
+	// JSON string encoding never uses fewer bytes than the UTF-8 input plus its
+	// quotes. Avoid copying a multi-megabyte body merely to prove that it cannot
+	// fit a 64 KiB value budget.
+	if len(value)+2 <= limit {
+		raw, _ := json.Marshal(value)
+		if len(raw) <= limit {
+			return raw, true
+		}
+	}
+
+	marker := fmt.Sprintf("…[aiscan: truncated, %d bytes total]", len(value))
+	markerRaw, _ := json.Marshal(marker)
+	if len(markerRaw) > limit {
+		return []byte(`""`), true
+	}
+
+	// JSON escaping means an N-byte prefix does not necessarily occupy N bytes
+	// on the wire. Find the largest UTF-8-safe prefix whose encoded form plus the
+	// complete marker stays inside the value budget.
+	low := 0
+	high := min(len(value), limit-len(markerRaw)+2)
+	best := markerRaw
+	for low <= high {
+		middle := low + (high-low)/2
+		prefix := strings.ToValidUTF8(value[:middle], "")
+		candidate, _ := json.Marshal(prefix + marker)
+		if len(candidate) <= limit {
+			best = candidate
+			low = middle + 1
+		} else {
+			high = middle - 1
+		}
+	}
+	return best, true
+}
+
+func marshalBoundedArtifactArray(items []any, limit, depth int) ([]byte, bool) {
+	if limit < 2 {
+		return nil, false
+	}
+	out := make([]byte, 0, min(limit, 1024))
+	out = append(out, '[')
+	written := 0
+	for _, item := range items {
+		separatorBytes := 0
+		if written > 0 {
+			separatorBytes = 1
+		}
+		remaining := limit - len(out) - separatorBytes - 1 // closing ']'
+		if remaining <= 0 {
+			break
+		}
+		itemBudget := min(remaining, maxArtifactOtherValueBytes)
+		encoded, ok := marshalBoundedArtifactValue(item, itemBudget, depth)
+		if !ok {
+			continue
+		}
+		if written > 0 {
+			out = append(out, ',')
+		}
+		out = append(out, encoded...)
+		written++
+	}
+	out = append(out, ']')
+	return out, true
+}
+
+func marshalBoundedArtifactMap(fields map[string]any, limit, depth int) ([]byte, bool) {
+	if limit < 2 {
+		return nil, false
+	}
+	keys := make([]string, 0, len(fields))
+	for name := range fields {
+		keys = append(keys, name)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		left := artifactFieldPriority(keys[i], fields[keys[i]])
+		right := artifactFieldPriority(keys[j], fields[keys[j]])
+		if left != right {
+			return left < right
+		}
+		return keys[i] < keys[j]
+	})
+
+	out := make([]byte, 0, min(limit, 1024))
+	out = append(out, '{')
+	written := 0
+	for _, name := range keys {
+		if limit-len(out)-1 < len("null") {
+			break
+		}
+		// Escaping can only make a JSON object key larger. Skip an impossible key
+		// without allocating a second copy of a peer-controlled multi-megabyte name.
+		if len(name)+2 > limit-len(out)-2 {
+			continue
+		}
+		encodedName, _ := json.Marshal(name)
+		separatorBytes := 0
+		if written > 0 {
+			separatorBytes = 1
+		}
+		entryBytes := separatorBytes + len(encodedName) + 1 // key + ':'
+		remaining := limit - len(out) - entryBytes - 1      // closing '}'
+		if remaining <= 0 {
+			continue
+		}
+		valueBudget := min(remaining, artifactFieldValueBudget(name, fields[name]))
+		encodedValue, ok := marshalBoundedArtifactValue(fields[name], valueBudget, depth)
+		if !ok {
+			continue
+		}
+		if written > 0 {
+			out = append(out, ',')
+		}
+		out = append(out, encodedName...)
+		out = append(out, ':')
+		out = append(out, encodedValue...)
+		written++
+	}
+	out = append(out, '}')
+	return out, true
+}
+
+func artifactFieldPriority(name string, value any) int {
+	if name == artifactBudgetMetadataField {
+		return 0
+	}
+	if isArtifactProjectionField(name) || isArtifactProjectionContainer(name, value) {
+		return 1
+	}
+	if !isArtifactBulkField(name) && isArtifactScalar(value) {
+		return 2
+	}
+	if isArtifactBulkField(name) {
+		return 4
+	}
+	return 3
+}
+
+func artifactFieldValueBudget(name string, value any) int {
+	if name == artifactBudgetMetadataField {
+		return 4 << 10
+	}
+	if isArtifactProjectionField(name) || isArtifactProjectionContainer(name, value) {
+		return maxArtifactProjectedValueBytes
+	}
+	if isArtifactBulkField(name) {
+		return maxArtifactStringBytes
+	}
+	return maxArtifactOtherValueBytes
+}
+
+func isArtifactProjectionContainer(name string, value any) bool {
+	name = strings.ToLower(name)
+	if name != "request" && name != "response" {
+		return false
+	}
+	switch value.(type) {
+	case []any, map[string]any:
+		return true
+	default:
+		return false
+	}
+}
+
+func isArtifactScalar(value any) bool {
+	switch value.(type) {
+	case nil, bool, json.Number, string:
+		return true
+	default:
+		return false
+	}
+}
+
+func isArtifactBulkField(name string) bool {
+	switch strings.ToLower(name) {
+	case "body", "content", "data", "header", "payload", "raw",
+		"request", "request_body", "request_raw",
+		"response", "response_body", "response_raw":
+		return true
+	default:
+		return false
+	}
+}
+
+// These are the scalar fields and small collections consumed by scanner-to-
+// graph projections. Keeping the list at the artifact boundary makes the
+// fallback deterministic without coupling the transport to one concrete Go
+// result type.
+func isArtifactProjectionField(name string) bool {
+	switch strings.ToLower(name) {
+	case "app_id", "asset_id", "attributes", "body_length", "content_length",
+		"content_type", "cstx_id", "cstx_type", "endpoint", "error",
+		"extracted", "extracts", "fingerprint", "frameworks", "front_url",
+		"froms", "header_length", "host", "hostname", "ip", "is_focus",
+		"issuer", "matched", "matcher_name", "method", "midware", "mod",
+		"name", "not_after", "not_before", "param", "password", "path",
+		"port", "product", "protocol", "reason", "redirect_url", "san",
+		"scheme", "serial", "service", "severity", "source", "source_url",
+		"status", "status_code", "subject", "tags", "target", "technologies",
+		"template_id", "template_name", "timestamp", "timing", "title", "uri",
+		"url", "username", "value", "vendor", "version", "vuln_id", "vulns":
+		return true
+	default:
+		return false
+	}
 }

--- a/tools/toolargs/artifact_budget_test.go
+++ b/tools/toolargs/artifact_budget_test.go
@@ -1,10 +1,17 @@
 package toolargs
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
+	aop "github.com/chainreactors/aiscan/aop"
+	toolpb "github.com/chainreactors/aiscan/aop/tool"
+	"github.com/chainreactors/aiscan/core/eventbus"
+	coretool "github.com/chainreactors/aiscan/core/tool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -90,13 +97,13 @@ func TestOversizedRecordKeepsItsFieldsAndLosesOnlyBulk(t *testing.T) {
 		"response.raw":  record.Response.Raw,
 	} {
 		assert.Contains(t, cut, "aiscan: truncated, 5242880 bytes total", name)
+		assert.LessOrEqual(t, len(cut), maxArtifactStringBytes, name)
 	}
 }
 
-// data reaching this function is always json.Marshal output, so it always
-// parses and truncatedStrings always reaches its strings. The contract holds
-// even for a record whose bulk is spread across many small strings rather than
-// a few large ones: never nil, never larger than the input.
+// A per-string ceiling alone cannot bound a record whose bulk is spread across
+// many modest values. The global encoder must stop the collection while keeping
+// the projection fields that precede it.
 func TestManySmallStringsAreBoundedAndNeverDropped(t *testing.T) {
 	values := make([]any, 200000)
 	for i := range values {
@@ -109,8 +116,116 @@ func TestManySmallStringsAreBoundedAndNeverDropped(t *testing.T) {
 	bounded := boundArtifactData(data)
 
 	require.NotNil(t, bounded)
+	require.LessOrEqual(t, len(bounded), maxArtifactDataBytes, "aggregate short strings must still obey the hard budget")
 	assert.LessOrEqual(t, len(bounded), len(data), "the result is never larger than the input")
-	var probe map[string]any
+	var probe struct {
+		Endpoint string   `json:"endpoint"`
+		Rows     []string `json:"rows"`
+		Budget   struct {
+			OriginalBytes int  `json:"original_bytes"`
+			Truncated     bool `json:"truncated"`
+		} `json:"_aiscan_artifact"`
+	}
 	require.NoError(t, json.Unmarshal(bounded, &probe), "the result is always valid JSON")
-	assert.Equal(t, "http://target/list", probe["endpoint"])
+	assert.Equal(t, "http://target/list", probe.Endpoint)
+	assert.NotEmpty(t, probe.Rows, "the record must retain useful collection data")
+	assert.Less(t, len(probe.Rows), len(values), "the oversized collection must be bounded")
+	assert.Equal(t, len(data), probe.Budget.OriginalBytes)
+	assert.True(t, probe.Budget.Truncated)
+}
+
+func TestNearLimitStringsCannotGrowAnOversizedRecord(t *testing.T) {
+	values := make([]any, 9000)
+	for i := range values {
+		values[i] = strings.Repeat("A", 513)
+	}
+	data, err := json.Marshal(map[string]any{"endpoint": "http://target/list", "rows": values})
+	require.NoError(t, err)
+	require.Greater(t, len(data), maxArtifactDataBytes)
+
+	bounded := boundArtifactData(data)
+
+	require.LessOrEqual(t, len(bounded), maxArtifactDataBytes)
+	assert.Less(t, len(bounded), len(data), "a truncation marker must never make the record larger")
+	assert.True(t, json.Valid(bounded))
+}
+
+func TestTruncationMarkerFitsInsideStringBudget(t *testing.T) {
+	value := strings.Repeat("界", maxArtifactStringBytes)
+
+	encoded, ok := marshalBoundedArtifactString(value, 512)
+
+	require.True(t, ok)
+	require.LessOrEqual(t, len(encoded), 512)
+	var decoded string
+	require.NoError(t, json.Unmarshal(encoded, &decoded))
+	assert.Contains(t, decoded, "aiscan: truncated")
+	assert.True(t, utf8.ValidString(decoded))
+	assert.Less(t, len(decoded), len(value))
+}
+
+func TestOversizedRecordKeepsNumberTextVerbatim(t *testing.T) {
+	data, err := json.Marshal(map[string]any{
+		"body":  strings.Repeat("A", 5<<20),
+		"port":  json.Number("9007199254740993"),
+		"ratio": json.Number("1e+09"),
+	})
+	require.NoError(t, err)
+
+	bounded := boundArtifactData(data)
+
+	decoder := json.NewDecoder(bytes.NewReader(bounded))
+	decoder.UseNumber()
+	var record map[string]any
+	require.NoError(t, decoder.Decode(&record))
+	assert.Equal(t, "9007199254740993", record["port"].(json.Number).String())
+	assert.Equal(t, "1e+09", record["ratio"].(json.Number).String())
+}
+
+func TestInvalidOversizedJSONFallsBackToBoundedRecord(t *testing.T) {
+	data := bytes.Repeat([]byte{'{'}, maxArtifactDataBytes+1)
+
+	bounded := boundArtifactData(data)
+
+	require.LessOrEqual(t, len(bounded), maxArtifactDataBytes)
+	require.True(t, json.Valid(bounded))
+	var record struct {
+		Budget struct {
+			OriginalBytes  int  `json:"original_bytes"`
+			PayloadOmitted bool `json:"payload_omitted"`
+			Truncated      bool `json:"truncated"`
+		} `json:"_aiscan_artifact"`
+	}
+	require.NoError(t, json.Unmarshal(bounded, &record))
+	assert.Equal(t, len(data), record.Budget.OriginalBytes)
+	assert.True(t, record.Budget.PayloadOmitted)
+	assert.True(t, record.Budget.Truncated)
+}
+
+func TestArtifactEmissionBoundsDataWithoutChangingIdentity(t *testing.T) {
+	bus := eventbus.New[*aop.Event]()
+	base := &Base{Events: bus}
+	base.InitLogger(nil)
+	data := map[string]any{
+		"body":     strings.Repeat("A", 5<<20),
+		"endpoint": "http://target/bundle.js",
+	}
+	wantID := ArtifactResultID("katana", toolpb.ArtifactKindWeb, "http://target/bundle.js", data)
+	var artifact *toolpb.Artifact
+	unsubscribe := bus.Subscribe(func(event *aop.Event) {
+		decoded := new(toolpb.Artifact)
+		if extension := event.GetExtension(); extension != nil && extension.UnmarshalTo(decoded) == nil {
+			artifact = decoded
+		}
+	})
+	defer unsubscribe()
+	ctx := coretool.ContextWithInvocation(context.Background(), coretool.Invocation{CallID: "call-1"})
+
+	base.EmitArtifactCtx(ctx, "katana", toolpb.ArtifactKindWeb, "http://target/bundle.js", data)
+
+	require.NotNil(t, artifact)
+	assert.Equal(t, wantID, artifact.GetResultId())
+	assert.Equal(t, "call-1", artifact.GetCallId())
+	require.LessOrEqual(t, len(artifact.GetData()), maxArtifactDataBytes)
+	assert.True(t, json.Valid(artifact.GetData()))
 }

--- a/tools/toolargs/artifact_budget_test.go
+++ b/tools/toolargs/artifact_budget_test.go
@@ -1,0 +1,116 @@
+package toolargs
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// katanaRecord is the JSON shape katana puts on the artifact channel:
+// output.Result wrapping navigation.Request and navigation.Response. The URL is
+// keyed `endpoint`, and bulk lands in four places — request.body carries a POST
+// form the same way response.body carries a page, and each is shadowed by its
+// raw transcript. A guard keyed on field names would have to know all four; a
+// guard on string length reaches every one.
+func katanaRecord(t *testing.T, bulk string) []byte {
+	t.Helper()
+	data, err := json.Marshal(map[string]any{
+		"timestamp": "2026-08-14T09:00:00Z",
+		"request": map[string]any{
+			"method":   "POST",
+			"endpoint": "http://target/bundle.js",
+			"body":     bulk,
+			"raw":      bulk,
+			"source":   "script",
+		},
+		"response": map[string]any{
+			"status_code":    200,
+			"content_length": len(bulk),
+			"body":           bulk,
+			"raw":            bulk,
+			"technologies":   []any{"nginx"},
+		},
+	})
+	require.NoError(t, err)
+	return data
+}
+
+func TestArtifactWithinBudgetIsReturnedUntouched(t *testing.T) {
+	data := katanaRecord(t, "ok")
+
+	bounded := boundArtifactData(data)
+
+	assert.Equal(t, string(data), string(bounded), "a record within budget must not be re-encoded")
+}
+
+// A katana crawl of a large page embeds the whole response body and the raw
+// transcript of that same response. That single record can outgrow the frame
+// that carries it; trimmed at birth, it stays a usable record instead of being
+// dropped whole downstream.
+func TestOversizedRecordKeepsItsFieldsAndLosesOnlyBulk(t *testing.T) {
+	bulk := strings.Repeat("A", 5<<20)
+	data := katanaRecord(t, bulk)
+	require.Greater(t, len(data), maxArtifactDataBytes)
+
+	bounded := boundArtifactData(data)
+
+	require.LessOrEqual(t, len(bounded), maxArtifactDataBytes, "a trimmed record must fit the budget")
+	require.Less(t, len(bounded), len(data))
+
+	var record struct {
+		Request struct {
+			Method   string `json:"method"`
+			Endpoint string `json:"endpoint"`
+			Body     string `json:"body"`
+			Raw      string `json:"raw"`
+		} `json:"request"`
+		Response struct {
+			StatusCode    json.Number `json:"status_code"`
+			ContentLength json.Number `json:"content_length"`
+			Body          string      `json:"body"`
+			Raw           string      `json:"raw"`
+			Technologies  []string    `json:"technologies"`
+		} `json:"response"`
+	}
+	require.NoError(t, json.Unmarshal(bounded, &record))
+	// The small fields a control plane projects into its graph survive intact;
+	// only the bulk that made the record unsendable is cut, and it says so.
+	assert.Equal(t, "http://target/bundle.js", record.Request.Endpoint)
+	assert.Equal(t, "POST", record.Request.Method)
+	assert.Equal(t, "200", record.Response.StatusCode.String(), "numbers must survive a re-encode verbatim")
+	assert.Equal(t, "5242880", record.Response.ContentLength.String())
+	assert.Equal(t, []string{"nginx"}, record.Response.Technologies)
+	for name, cut := range map[string]string{
+		"request.body":  record.Request.Body,
+		"request.raw":   record.Request.Raw,
+		"response.body": record.Response.Body,
+		"response.raw":  record.Response.Raw,
+	} {
+		assert.Contains(t, cut, "aiscan: truncated, 5242880 bytes total", name)
+	}
+}
+
+// data reaching this function is always json.Marshal output, so it always
+// parses and truncatedStrings always reaches its strings. The contract holds
+// even for a record whose bulk is spread across many small strings rather than
+// a few large ones: never nil, never larger than the input.
+func TestManySmallStringsAreBoundedAndNeverDropped(t *testing.T) {
+	values := make([]any, 200000)
+	for i := range values {
+		values[i] = "row-of-modest-length-that-adds-up-across-many-entries"
+	}
+	data, err := json.Marshal(map[string]any{"endpoint": "http://target/list", "rows": values})
+	require.NoError(t, err)
+	require.Greater(t, len(data), maxArtifactDataBytes)
+
+	bounded := boundArtifactData(data)
+
+	require.NotNil(t, bounded)
+	assert.LessOrEqual(t, len(bounded), len(data), "the result is never larger than the input")
+	var probe map[string]any
+	require.NoError(t, json.Unmarshal(bounded, &probe), "the result is always valid JSON")
+	assert.Equal(t, "http://target/list", probe["endpoint"])
+}

--- a/tools/toolargs/base.go
+++ b/tools/toolargs/base.go
@@ -54,6 +54,15 @@ func (b *Base) EmitArtifactResultCtx(ctx context.Context, resultID, tool, kind, 
 		b.Logger.Warnf("marshal %s artifact: %s", tool, err)
 		return
 	}
+	// One artifact event is one control-plane frame. A record that outgrows the
+	// frame is trimmed to fit here, at the sole point every tool's artifact is
+	// built, rather than dropped whole by a frame guard downstream. resultID stays
+	// keyed on the untrimmed data above, so a record's identity is stable whether
+	// or not its transport representation had to shed bulk.
+	if bounded := boundArtifactData(raw); len(bounded) < len(raw) {
+		b.Logger.Warnf("artifact budget: %s %s for %.200s trimmed %d → %d bytes", tool, kind, target, len(raw), len(bounded))
+		raw = bounded
+	}
 	invocation := coretool.InvocationFromContext(ctx)
 	artifact := &toolpb.Artifact{
 		Tool: tool, Kind: kind, Target: target, Data: raw,


### PR DESCRIPTION
## 问题

控制面把一个 artifact 事件当作一个 WebSocket 帧接收,并对帧大小设限:超过软限丢弃该消息,超过硬限直接关闭连接——连带把该连接上正在进行的所有工具调用一起中断。

扫描类工具的原生记录是唯一没有自然上限的 artifact:一条 katana 抓取结果会把响应体和同一响应的原始报文各存一份,katana 自身的响应体上限就有 4 MiB,单条记录因此可达 8–10 MiB,足以越过帧限。

## 改动

`EmitArtifactResultCtx` 是所有工具构造 artifact 的唯一入口(全仓仅此一处 `toolpb.Artifact{}`),katana/gogo/spray/neutron 等全部经它。此处的 `raw` 正是刚 `json.Marshal` 出来的、保证可解析的结构化 JSON——所以在这里封顶,而不是留给下游帧层。

`boundArtifactData`:记录超过 4 MiB 时,按字符串长度逐级收紧,截短响应体 / 原始报文等大字段,保留控制面要投影进图谱的小字段(URL、host、端口、状态、指纹),数字保留原文本(不会把端口或 ID 四舍五入),并丢弃字节截断留下的半个 rune(否则下游 marshal 失败)。

关键性质:**永不丢一条扫描记录**——最坏也是截到最小再发。这正是出生点相对于传输点的优势:这里 data 是结构化 JSON,能精准截 body / raw;下游帧层拿到的是 opaque bytes,只能整条丢弃。`resultID` 仍基于未截断的原始 data,记录身份在截断前后保持稳定。

## 测试

`tools/toolargs/artifact_budget_test.go`,基于 katana 真实 wire 形状(`endpoint` / `body` / `raw`,含 `request.body`):

- 预算内原样透传
- 超大记录:四处大字段全部截短,投影小字段与数字原样保留
- 大量小字符串累加超限:永不返回 nil、永不比输入更大、结果始终是合法 JSON
