### PR TITLE
fix(proxy): bound and reclaim MITM body captures

### DIFF
--- a/aop/traffic/body.go
+++ b/aop/traffic/body.go
@@ -15,7 +15,9 @@ import (
 // only the configured preview; callers that need the complete payload can
 // hydrate it from Path.
 type BodyRef struct {
-	Path      string `json:"path,omitempty"`
+	Path string `json:"path,omitempty"`
+	// Size is the number of bytes observed from the stream. When Truncated is
+	// true, Path contains only the retained prefix.
 	Size      int64  `json:"size"`
 	SHA256    string `json:"sha256,omitempty"`
 	Complete  bool   `json:"complete"`
@@ -31,16 +33,27 @@ type BodySink struct {
 	file       *os.File
 	hash       hash.Hash
 	size       int64
+	storedSize int64
+	maxBytes   int64
 	preview    []byte
 	previewMax int
 	err        error
 	closed     bool
 	complete   bool
+	truncated  bool
 }
 
 // NewBodySink creates <name>.part in dir and atomically publishes it as name
 // when Close(true) succeeds. The directory is created when needed.
 func NewBodySink(dir, name string, previewMax int) (*BodySink, error) {
+	return NewBodySinkWithLimit(dir, name, previewMax, 0)
+}
+
+// NewBodySinkWithLimit is NewBodySink with an optional maximum number of
+// bytes retained on disk. Bytes beyond the limit are consumed by Reader and
+// counted in BodyRef.Size, but are not written; BodyRef.Truncated marks the
+// resulting file as a prefix.
+func NewBodySinkWithLimit(dir, name string, previewMax int, maxBytes int64) (*BodySink, error) {
 	if dir == "" {
 		return nil, fmt.Errorf("traffic: body directory is empty")
 	}
@@ -62,6 +75,7 @@ func NewBodySink(dir, name string, previewMax int) (*BodySink, error) {
 		finalPath:  finalPath,
 		file:       f,
 		hash:       h,
+		maxBytes:   maxBytes,
 		previewMax: previewMax,
 	}, nil
 }
@@ -79,22 +93,57 @@ func (s *BodySink) Write(p []byte) (int, error) {
 	if s.err != nil {
 		return 0, s.err
 	}
+	if s.maxBytes > 0 {
+		// Keep consuming the source stream so capture never changes proxy
+		// forwarding, but persist only the configured prefix.
+		s.size += int64(len(p))
+		remaining := s.maxBytes - s.storedSize
+		if remaining <= 0 {
+			s.truncated = true
+			return len(p), nil
+		}
+		writeLen := len(p)
+		if int64(writeLen) > remaining {
+			writeLen = int(remaining)
+			s.truncated = true
+		}
+		n, err := s.file.Write(p[:writeLen])
+		if n > 0 {
+			s.storedSize += int64(n)
+			_, _ = s.hash.Write(p[:n])
+			s.appendPreviewLocked(p[:n])
+		}
+		if err == nil && n != writeLen {
+			err = io.ErrShortWrite
+		}
+		if err != nil {
+			s.err = err
+			return n, err
+		}
+		return len(p), nil
+	}
 	n, err := s.file.Write(p)
 	if n > 0 {
 		s.size += int64(n)
+		s.storedSize += int64(n)
 		_, _ = s.hash.Write(p[:n])
-		if len(s.preview) < s.previewMax {
-			end := len(p)
-			if remaining := s.previewMax - len(s.preview); end > remaining {
-				end = remaining
-			}
-			s.preview = append(s.preview, p[:end]...)
-		}
+		s.appendPreviewLocked(p[:n])
 	}
 	if err != nil {
 		s.err = err
 	}
 	return n, err
+}
+
+func (s *BodySink) appendPreviewLocked(p []byte) {
+	if len(s.preview) >= s.previewMax || len(p) == 0 {
+		return
+	}
+	end := len(p)
+	if remaining := s.previewMax - len(s.preview); end > remaining {
+		end = remaining
+	}
+	s.preview = append(s.preview, p[:end]...)
 }
 
 // Reader wraps r so body bytes are captured as they pass through the proxy.
@@ -186,7 +235,7 @@ func (s *BodySink) refLocked() BodyRef {
 		Size:      s.size,
 		SHA256:    digest,
 		Complete:  s.complete,
-		Truncated: false,
+		Truncated: s.truncated,
 	}
 }
 

--- a/aop/traffic/body_test.go
+++ b/aop/traffic/body_test.go
@@ -2,6 +2,8 @@ package traffic
 
 import (
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -25,5 +27,30 @@ func TestBodySinkStreamsAndHydrates(t *testing.T) {
 	body, err := ReadBody(&ref)
 	if err != nil || string(body) != "abcdefgh" {
 		t.Fatalf("body=%q err=%v", body, err)
+	}
+}
+
+func TestBodySinkLimitRetainsPrefix(t *testing.T) {
+	dir := t.TempDir()
+	sink, err := NewBodySinkWithLimit(dir, "response", 4, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n, err := io.Copy(sink, strings.NewReader("abcdefgh")); err != nil || n != 8 {
+		t.Fatalf("copy n=%d err=%v, want all 8 bytes consumed", n, err)
+	}
+	ref, err := sink.Close(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref.Size != 8 || !ref.Truncated || !ref.Complete {
+		t.Fatalf("ref=%+v, want complete truncated capture", ref)
+	}
+	body, err := ReadBody(&ref)
+	if err != nil || string(body) != "abcd" {
+		t.Fatalf("stored body=%q err=%v, want prefix", body, err)
+	}
+	if info, err := os.Stat(filepath.Join(dir, "response")); err != nil || info.Size() != 4 {
+		t.Fatalf("stored file stat=%v info=%v, want 4 bytes", err, info)
 	}
 }

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -273,7 +273,7 @@ Agent 模式下还可通过 `proxy` 工具在运行时动态管理代理，详�
 
 捕获默认开启,可用 `--mitm=false` 或配置 `mitm: false` 关闭(转为纯路由,不拦截 HTTPS、不抓包、无需信任 CA)。HTTPS 捕获会为工具注入 Hub CA(`CURL_CA_BUNDLE`/`SSL_CERT_FILE` 等);对**裸 IP** 目标的 HTTPS 因证书无 IP SAN 可能被严格校验拒绝,使用主机名不受影响。
 
-作为 Cairn Runner 运行时,每次工具执行的完整流量会作为 `http.exchange.v1` 证据进入流量表(敏感头在 Runner 侧脱敏),覆盖全部工具流量而非仅漏洞相关的零散记录。
+作为 Cairn Runner 运行时,每次工具执行的流量元数据和 body 前缀会作为 `http.exchange.v1` 证据进入流量表(敏感头在 Runner 侧脱敏),覆盖全部工具流量而非仅漏洞相关的零散记录。单个 body 最多保留 8 MiB,淘汰流量时对应文件会回收。
 
 ### LLM API 代理
 

--- a/tools/proxy/mitm.go
+++ b/tools/proxy/mitm.go
@@ -173,6 +173,12 @@ func (c *MitmCommand) analyze(args []string) (string, error) {
 
 const maxBodySnip = 4096
 
+// Bound durable capture without changing the bytes forwarded through the
+// proxy. Each request/response keeps at most 8 MiB; the ring keeps at most 2
+// GiB of retained body data in total.
+const maxBodyCaptureBytes int64 = 8 << 20
+const defaultMaxBodyBytes int64 = 2 << 30
+
 type captureAddon struct {
 	mitmproxy.BaseAddon
 	hub     *ProxyHub
@@ -609,7 +615,7 @@ func (s *FlowStore) bodySink(proxyID, side string) (*traffic.BodySink, error) {
 	if dir == "" {
 		return nil, nil
 	}
-	return traffic.NewBodySink(filepath.Join(dir, "body"), proxyID+"."+side, maxBodySnip)
+	return traffic.NewBodySinkWithLimit(filepath.Join(dir, "body"), proxyID+"."+side, maxBodySnip, maxBodyCaptureBytes)
 }
 
 type QueryOpts struct {
@@ -620,24 +626,39 @@ type QueryOpts struct {
 }
 
 type FlowStore struct {
-	mu        sync.RWMutex
-	flows     []Flow
-	head      int
-	size      int
-	seq       int
-	cap       int
-	bodyDir   string
-	indexPath string
-	indexFile *os.File
-	indexMu   sync.Mutex
-	indexErr  error
+	mu           sync.RWMutex
+	flows        []Flow
+	head         int
+	size         int
+	seq          int
+	cap          int
+	bodyBytes    int64
+	maxBodyBytes int64
+	bodyDir      string
+	indexPath    string
+	indexFile    *os.File
+	indexMu      sync.Mutex
+	indexErr     error
 }
 
 func NewFlowStore(cap int) *FlowStore {
+	return NewFlowStoreWithLimits(cap, defaultMaxBodyBytes)
+}
+
+// NewFlowStoreWithLimits sets the retained body budget. A non-positive budget
+// disables only the aggregate limit; each proxy body is still capped.
+func NewFlowStoreWithLimits(cap int, maxBodyBytes int64) *FlowStore {
 	if cap <= 0 {
 		cap = 10000
 	}
-	return &FlowStore{flows: make([]Flow, cap), cap: cap}
+	if maxBodyBytes < 0 {
+		maxBodyBytes = 0
+	}
+	return &FlowStore{
+		flows:        make([]Flow, cap),
+		cap:          cap,
+		maxBodyBytes: maxBodyBytes,
+	}
 }
 
 // SetBodyDir enables disk-backed request/response bodies for flows captured by
@@ -668,6 +689,7 @@ func (s *FlowStore) SetBodyDir(dir string) error {
 	s.indexPath = indexPath
 	s.indexFile = file
 	s.mu.Unlock()
+	s.pruneBodyFiles()
 	return nil
 }
 
@@ -675,6 +697,105 @@ func (s *FlowStore) BodyDir() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.bodyDir
+}
+
+func flowBodyRefs(flow Flow) []*traffic.BodyRef {
+	refs := make([]*traffic.BodyRef, 0, 2)
+	if flow.Request.BodyRef != nil {
+		refs = append(refs, flow.Request.BodyRef)
+	}
+	if flow.Response != nil && flow.Response.BodyRef != nil {
+		refs = append(refs, flow.Response.BodyRef)
+	}
+	return refs
+}
+
+func flowBodySize(flow Flow) int64 {
+	var size int64
+	for _, ref := range flowBodyRefs(flow) {
+		if ref != nil && ref.Size > 0 {
+			size += ref.Size
+		}
+	}
+	return size
+}
+
+func bodyPath(root, raw string) string {
+	if raw == "" {
+		return ""
+	}
+	if !filepath.IsAbs(raw) {
+		raw = filepath.Join(root, raw)
+	}
+	return filepath.Clean(raw)
+}
+
+func removeBodyPath(path string) {
+	if path == "" {
+		return
+	}
+	_ = os.Remove(path)
+	if strings.HasSuffix(path, ".part") {
+		_ = os.Remove(strings.TrimSuffix(path, ".part"))
+	} else {
+		_ = os.Remove(path + ".part")
+	}
+}
+
+func (s *FlowStore) removeFlowBodies(flow Flow) {
+	s.mu.RLock()
+	root := s.bodyDir
+	s.mu.RUnlock()
+	if root == "" {
+		return
+	}
+	for _, ref := range flowBodyRefs(flow) {
+		if ref != nil {
+			removeBodyPath(bodyPath(root, ref.Path))
+		}
+	}
+}
+
+// pruneBodyFiles reconciles the body subtree with the flows retained in the
+// ring. It runs at startup so files left by a crash or an older ring are not
+// carried forward forever.
+func (s *FlowStore) pruneBodyFiles() {
+	s.mu.RLock()
+	root := s.bodyDir
+	live := make(map[string]struct{})
+	for n := 0; n < s.size; n++ {
+		flow := s.flows[(s.head+n)%s.cap]
+		for _, ref := range flowBodyRefs(flow) {
+			if ref != nil {
+				path := bodyPath(root, ref.Path)
+				if path != "" {
+					if abs, err := filepath.Abs(path); err == nil {
+						live[abs] = struct{}{}
+					}
+				}
+			}
+		}
+	}
+	s.mu.RUnlock()
+	if root == "" {
+		return
+	}
+	_ = filepath.Walk(filepath.Join(root, "body"), func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info == nil || info.IsDir() {
+			return nil
+		}
+		absolute, absErr := filepath.Abs(path)
+		if absErr != nil {
+			return absErr
+		}
+		if _, ok := live[absolute]; !ok {
+			_ = os.Remove(path)
+		}
+		return nil
+	})
 }
 
 // IndexError reports a metadata append failure. The in-memory/ring capture is
@@ -718,18 +839,29 @@ func (s *FlowStore) After(id int) []Flow { return s.after(id) }
 // Add stores f, assigns it a monotonic ID, and returns the stored copy so the
 // caller can fan the ID-bearing flow out to subscribers.
 func (s *FlowStore) Add(f Flow) Flow {
+	incomingBytes := flowBodySize(f)
+	var evicted []Flow
 	s.mu.Lock()
 	s.seq++
 	f.ID = strconv.Itoa(s.seq)
-	idx := (s.head + s.size) % s.cap
-	if s.size == s.cap {
-		idx = s.head
+	for s.size > 0 && (s.size == s.cap ||
+		(s.maxBodyBytes > 0 && s.bodyBytes+incomingBytes > s.maxBodyBytes)) {
+		evicted = append(evicted, s.flows[s.head])
+		s.bodyBytes -= flowBodySize(s.flows[s.head])
+		if s.bodyBytes < 0 {
+			s.bodyBytes = 0
+		}
 		s.head = (s.head + 1) % s.cap
-	} else {
-		s.size++
+		s.size--
 	}
+	idx := (s.head + s.size) % s.cap
 	s.flows[idx] = f
+	s.size++
+	s.bodyBytes += incomingBytes
 	s.mu.Unlock()
+	for _, old := range evicted {
+		s.removeFlowBodies(old)
+	}
 	s.appendIndex(f)
 	return f
 }
@@ -843,14 +975,20 @@ func (s *FlowStore) putLocked(f Flow) {
 	if seq := flowSequence(f.ID); seq > s.seq {
 		s.seq = seq
 	}
-	idx := (s.head + s.size) % s.cap
-	if s.size == s.cap {
-		idx = s.head
+	incomingBytes := flowBodySize(f)
+	for s.size > 0 && (s.size == s.cap ||
+		(s.maxBodyBytes > 0 && s.bodyBytes+incomingBytes > s.maxBodyBytes)) {
+		s.bodyBytes -= flowBodySize(s.flows[s.head])
+		if s.bodyBytes < 0 {
+			s.bodyBytes = 0
+		}
 		s.head = (s.head + 1) % s.cap
-	} else {
-		s.size++
+		s.size--
 	}
+	idx := (s.head + s.size) % s.cap
 	s.flows[idx] = f
+	s.size++
+	s.bodyBytes += incomingBytes
 }
 
 func (s *FlowStore) Query(opts QueryOpts) []Flow {
@@ -907,6 +1045,7 @@ func (s *FlowStore) Clear() {
 	}
 	s.head = 0
 	s.size = 0
+	s.bodyBytes = 0
 	s.mu.Unlock()
 	s.indexMu.Lock()
 	s.indexErr = nil

--- a/tools/proxy/mitm_test.go
+++ b/tools/proxy/mitm_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -95,6 +97,91 @@ func TestCaptureFilterRunsBeforeStore(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	if got := hub.Store().Count(); got != 0 {
 		t.Fatalf("filtered flow count = %d, want 0", got)
+	}
+}
+
+func TestFlowStoreEvictsBodyFiles(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFlowStore(1)
+	if err := store.SetBodyDir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	write := func(name string) string {
+		t.Helper()
+		path := filepath.Join(dir, "body", name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(name), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	add := func(path string) {
+		store.Add(Flow{Exchange: traffic.Exchange{
+			Request:  traffic.Request{Method: "GET", URL: "https://example.test/"},
+			Response: &traffic.Response{StatusCode: 200, BodyRef: &traffic.BodyRef{Path: path, Size: 1}},
+		}})
+	}
+	first := write("first.resp")
+	add(first)
+	second := write("second.resp")
+	add(second)
+
+	if _, err := os.Stat(first); !os.IsNotExist(err) {
+		t.Fatalf("evicted body still exists: %v", err)
+	}
+	if _, err := os.Stat(second); err != nil {
+		t.Fatalf("retained body missing: %v", err)
+	}
+}
+
+func TestFlowStoreBodyBudgetAndStartupPrune(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFlowStoreWithLimits(8, 10)
+	if err := store.SetBodyDir(dir); err != nil {
+		t.Fatal(err)
+	}
+	write := func(name string, size int) string {
+		t.Helper()
+		path := filepath.Join(dir, "body", name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, make([]byte, size), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	first := write("budget-first.resp", 6)
+	store.Add(Flow{Exchange: traffic.Exchange{Response: &traffic.Response{BodyRef: &traffic.BodyRef{Path: first, Size: 6}}}})
+	second := write("budget-second.resp", 6)
+	store.Add(Flow{Exchange: traffic.Exchange{Response: &traffic.Response{BodyRef: &traffic.BodyRef{Path: second, Size: 6}}}})
+	if store.Count() != 1 {
+		t.Fatalf("count=%d, want one flow after budget eviction", store.Count())
+	}
+	if _, err := os.Stat(first); !os.IsNotExist(err) {
+		t.Fatalf("budget-evicted body still exists: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	orphan := filepath.Join(dir, "body", "orphan.resp.part")
+	if err := os.WriteFile(orphan, []byte("orphan"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	reloaded := NewFlowStoreWithLimits(8, 10)
+	if err := reloaded.SetBodyDir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer reloaded.Close()
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Fatalf("startup orphan still exists: %v", err)
+	}
+	if _, err := os.Stat(second); err != nil {
+		t.Fatalf("live body removed at startup: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- cap each captured request/response body at 8 MiB while preserving the observed stream size and a truncation marker
- evict the oldest flows when the ring or 2 GiB retained-body budget is exceeded, deleting their body files
- remove unreferenced body and `.part` files when the MITM body directory is initialized

## Validation

- `go test ./tools/proxy -count=1`
- `go test -race ./tools/proxy -count=1`
- `cd aop && go test -race ./traffic`

`flows.jsonl` rotation remains a separate follow-up because this PR only addresses body-file retention.

Refs #118